### PR TITLE
Allow applications to read secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,8 @@ locals {
 
   read_principals = concat(
     local.execution_role_arns,
-    local.read_permission_set_roles
+    local.read_permission_set_roles,
+    [module.pod_role.arn],
   )
 
   readwrite_permission_set_roles = [
@@ -62,9 +63,14 @@ locals {
     module.sso_roles.by_name[name]
   ]
 
-  secret_principals = concat(
+  secret_write_principals = concat(
     local.execution_role_arns,
     local.secret_permission_set_roles
+  )
+
+  secret_read_principals = concat(
+    local.secret_write_principals,
+    [module.pod_role.arn]
   )
 
   secrets = concat(

--- a/secrets.tf
+++ b/secrets.tf
@@ -5,6 +5,8 @@ module "secret_key" {
   description           = "Secret key for ${local.instance_name}"
   environment_variables = [var.secret_key_variable]
   name                  = "${local.instance_name}-secret-key"
+  read_principals       = local.secret_read_principals
+  readwrite_principals  = local.secret_write_principals
 }
 
 module "secret_key_policy" {
@@ -24,8 +26,8 @@ module "developer_managed_secrets" {
   description           = "Developer-managed ${each.key} secrets for ${local.instance_name}"
   environment_variables = each.value
   name                  = "${local.instance_name}-${lower(each.key)}"
-  read_principals       = local.secret_principals
-  readwrite_principals  = local.secret_principals
+  read_principals       = local.secret_read_principals
+  readwrite_principals  = local.secret_write_principals
 }
 
 module "developer_managed_secrets_policy" {


### PR DESCRIPTION
This separates the read/write principals for secrets so that applications are allowed to read their secrets, but not to change them.
