### PR TITLE
Make secret policy creation dependent on admin login

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -48,4 +48,6 @@ module "postgres_policy" {
   policy_name  = "${local.instance_name}-postgres"
   role_names   = [module.pod_role.name]
   secret_names = [module.postgres_admin_login[count.index].secret_name]
+
+  depends_on = [module.postgres_admin_login]
 }


### PR DESCRIPTION
The secrets that are created with the admin login for Postgres need to
exist before we attach a policy to it.