### PR TITLE
Make policy to read Redis secret dependent on secret creation

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -31,4 +31,6 @@ module "redis_policy" {
   policy_name  = "${local.instance_name}-redis"
   role_names   = [module.pod_role.name]
   secret_names = [module.redis_token[count.index].secret_name]
+
+  depends_on = [module.redis_token]
 }


### PR DESCRIPTION
Similarly to seen on 8975d8f, the secret needs to exist before we assign a policy to it.