### PR TITLE
Use vpc subnet count to set availability zone count for opensearch

### DIFF
--- a/opensearch.tf
+++ b/opensearch.tf
@@ -58,7 +58,7 @@ module "opensearch" {
     instance_type            = coalesce(var.es_instance_type, var.es_dedicated_master_type)
 
     zone_awareness_config = {
-      availability_zone_count = 2
+      availability_zone_count = length(module.network.private_subnet_ids) > 3 ? 3 : length(module.network.private_subnet_ids)
     }
 
     zone_awareness_enabled = true
@@ -101,7 +101,7 @@ module "opensearch" {
   }
 
   vpc_options = {
-    subnet_ids = module.network.private_subnet_ids
+    subnet_ids = length(module.network.private_subnet_ids) > 3 ? slice(module.network.private_subnet_ids, 0, 3) : module.network.private_subnet_ids
   }
 
   # Security Group rule example


### PR DESCRIPTION
The availability zone count must match the number of subnet passed into the opensearch vpc option. This update dynamically checks the number of subnets passed and uses it to determine the number of availability zones for the cluster.
It also restricts the zone count to a max of 3 subnets.