### PR TITLE
Update dependencies AWS v5 provider versions

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -1,5 +1,5 @@
 module "deploy_role" {
-  source = "github.com/thoughtbot/terraform-eks-cicd//modules/github-actions-eks-deploy-role?ref=v0.2.0"
+  source = "github.com/thoughtbot/terraform-eks-cicd//modules/github-actions-eks-deploy-role?ref=v0.3.0"
 
   cluster_names         = var.cluster_names
   github_branches       = var.github_branches

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ module "sso_roles" {
 }
 
 module "pod_role" {
-  source = "github.com/thoughtbot/flightdeck//aws/service-account-role?ref=v0.9.0"
+  source = "github.com/thoughtbot/flightdeck//aws/service-account-role?ref=v0.11.0"
 
   cluster_names    = var.cluster_names
   name             = "${local.instance_name}-pods"
@@ -12,7 +12,7 @@ module "pod_role" {
 
 module "pod_policy" {
   count  = var.s3_enabled ? 1 : 0
-  source = "github.com/thoughtbot/flightdeck//aws/service-account-policy?ref=v0.9.0"
+  source = "github.com/thoughtbot/flightdeck//aws/service-account-policy?ref=v0.11.0"
 
   name             = "${local.instance_name}-pods"
   policy_documents = module.s3_bucket[*].policy_json
@@ -20,13 +20,13 @@ module "pod_policy" {
 }
 
 module "cluster" {
-  source = "github.com/thoughtbot/flightdeck//aws/cluster-name?ref=v0.9.0"
+  source = "github.com/thoughtbot/flightdeck//aws/cluster-name?ref=v0.11.0"
 
   name = var.cluster_names[0]
 }
 
 module "network" {
-  source = "github.com/thoughtbot/flightdeck//aws/network-data?ref=v0.9.0"
+  source = "github.com/thoughtbot/flightdeck//aws/network-data?ref=v0.11.0"
 
   tags = module.cluster.shared_tags
 }

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -444,7 +444,7 @@ resource "aws_vpc_security_group_egress_rule" "this" {
 }
 
 module "elasticsearch_secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Elastisearch secrets for: ${var.application_name}"

--- a/opensearch.tf
+++ b/opensearch.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "ecs_osis_access" {
 
 module "es_pod_policy" {
   count  = var.elasticsearch_enabled ? 1 : 0
-  source = "github.com/thoughtbot/flightdeck//aws/service-account-policy?ref=v0.9.0"
+  source = "github.com/thoughtbot/flightdeck//aws/service-account-policy?ref=v0.11.0"
 
   name = "es-${var.es_application_name}-pods"
   policy_documents = concat(

--- a/postgres.tf
+++ b/postgres.tf
@@ -1,6 +1,6 @@
 module "postgres" {
   count  = var.postgres_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-databases//rds-postgres/primary-instance?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-databases//rds-postgres/primary-instance?ref=v0.6.0"
 
   admin_username           = var.postgres_admin_username
   allocated_storage        = var.postgres_allocated_storage
@@ -28,7 +28,7 @@ resource "random_id" "parameter_group" {
 
 module "postgres_admin_login" {
   count  = var.postgres_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-databases//rds-postgres/admin-login?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-databases//rds-postgres/admin-login?ref=v0.6.0"
 
   database_name    = module.postgres[count.index].default_database
   identifier       = module.postgres[count.index].identifier
@@ -43,7 +43,7 @@ module "postgres_admin_login" {
 
 module "postgres_policy" {
   count  = var.postgres_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.6.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.8.0"
 
   policy_name  = "${local.instance_name}-postgres"
   role_names   = [module.pod_role.name]

--- a/redis.tf
+++ b/redis.tf
@@ -1,6 +1,6 @@
 module "redis" {
   count  = var.redis_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-databases//elasticache-redis/replication-group?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-databases//elasticache-redis/replication-group?ref=v0.6.0"
 
   allowed_cidr_blocks = [module.network.vpc.cidr_block]
   description         = "Redis cluster for ${local.instance_name} jobs"
@@ -14,7 +14,7 @@ module "redis" {
 
 module "redis_token" {
   count  = var.redis_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-databases//elasticache-redis/auth-token?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-databases//elasticache-redis/auth-token?ref=v0.6.0"
 
   initial_auth_token   = module.redis[count.index].initial_auth_token
   replication_group_id = module.redis[count.index].id
@@ -26,7 +26,7 @@ module "redis_token" {
 
 module "redis_policy" {
   count  = var.redis_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.6.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.8.0"
 
   policy_name  = "${local.instance_name}-redis"
   role_names   = [module.pod_role.name]

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 module "s3_bucket" {
   count  = var.s3_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-s3-bucket?ref=v0.3.0"
+  source = "github.com/thoughtbot/terraform-s3-bucket?ref=v0.4.0"
 
   name                 = var.s3_bucket_name
   read_principals      = concat(local.read_principals, var.s3_read_principals)

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,6 +1,6 @@
 module "secret_key" {
   count  = var.generate_secret_key ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-secrets//random-secret?ref=v0.6.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//random-secret?ref=v0.8.0"
 
   description           = "Secret key for ${local.instance_name}"
   environment_variables = [var.secret_key_variable]
@@ -11,7 +11,7 @@ module "secret_key" {
 
 module "secret_key_policy" {
   count  = var.generate_secret_key ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.6.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.8.0"
 
   policy_name  = "${local.instance_name}-secret-key"
   role_names   = [module.pod_role.name]
@@ -21,7 +21,7 @@ module "secret_key_policy" {
 module "developer_managed_secrets" {
   for_each = var.developer_managed_secrets
 
-  source = "github.com/thoughtbot/terraform-aws-secrets//user-managed-secret?ref=v0.5.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//user-managed-secret?ref=v0.8.0"
 
   description           = "Developer-managed ${each.key} secrets for ${local.instance_name}"
   environment_variables = each.value
@@ -31,7 +31,7 @@ module "developer_managed_secrets" {
 }
 
 module "developer_managed_secrets_policy" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.6.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//read-secret-policy?ref=v0.8.0"
 
   policy_name  = "${local.instance_name}-managed-secrets"
   role_names   = [module.pod_role.name]

--- a/sentry.tf
+++ b/sentry.tf
@@ -1,6 +1,6 @@
 module "sentry_dsn" {
   count  = var.sentry_enabled ? 1 : 0
-  source = "github.com/thoughtbot/terraform-aws-sentry-dsn?ref=v0.3.0"
+  source = "github.com/thoughtbot/terraform-aws-sentry-dsn?ref=v0.4.0"
 
   name              = var.sentry_project
   organization_slug = var.sentry_organization


### PR DESCRIPTION
Depends on https://github.com/thoughtbot/terraform-aws-databases/pull/34 and https://github.com/thoughtbot/flightdeck/pull/219.