### PR TITLE
Bump Terraform AWS provider from version 4 to 5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
 
     random = {


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0

Ref:
- https://trello.com/c/MIAiwlJ4/25-update-terraform-modules-to-support-aws-v5-providers