### PR TITLE
Add redis engine version var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ module "production" {
   postgres_max_allocated_storage = 128
 
   # Redis
-  redis_enabled       = true
-  redis_name          = "example-production-blue"
-  redis_node_type     = "cache.m6g.large"
-  redis_replica_count = 1
+  redis_enabled        = true
+  redis_name           = "example-production-blue"
+  redis_node_type      = "cache.m6g.large"
+  redis_replica_count  = 1
+  redis_engine_version = "7.x"
 
   # S3
   s3_enabled     = true
@@ -178,6 +179,7 @@ module "production_v1" {
 | <a name="input_redis_name"></a> [redis\_name](#input\_redis\_name) | Name of the ElastiCache instance for Redis | `string` | `null` | no |
 | <a name="input_redis_node_type"></a> [redis\_node\_type](#input\_redis\_node\_type) | Node type for the ElastiCache instance for Redis | `string` | `null` | no |
 | <a name="input_redis_replica_count"></a> [redis\_replica\_count](#input\_redis\_replica\_count) | Number of replicas for the Redis cluster | `number` | `null` | no |
+| <a name="input_redis_engine_version"></a> [redis\ engine\ version](#input\_redis\_engine\_version) | ElastiCache instance Redis version| `string` | `null` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Name of the S3 bucket for this application | `string` | `null` | no |
 | <a name="input_s3_enabled"></a> [s3\_enabled](#input\_s3\_enabled) | Set to true to enable creation of an S3 bucket | `bool` | `false` | no |
 | <a name="input_s3_read_principals"></a> [s3\_read\_principals](#input\_s3\_read\_principals) | Additional principals able to read S3 data | `list(string)` | `[]` | no |

--- a/redis-variables.tf
+++ b/redis-variables.tf
@@ -4,6 +4,12 @@ variable "redis_enabled" {
   default     = false
 }
 
+variable "redis_engine_version" {
+  description = "The version of redis to run"
+  type        = string
+  default     = "7.x"
+}
+
 variable "redis_enable_kms" {
   description = "Enable KMS encryption"
   type        = bool

--- a/redis.tf
+++ b/redis.tf
@@ -4,7 +4,7 @@ module "redis" {
 
   allowed_cidr_blocks = [module.network.vpc.cidr_block]
   description         = "Redis cluster for ${local.instance_name} jobs"
-  engine_version      = "6.x"
+  engine_version      = var.redis_engine_version
   name                = var.redis_name
   node_type           = var.redis_node_type
   replica_count       = var.redis_replica_count


### PR DESCRIPTION
Add a new variable for configuring redis engine version
Why this change is being made:
- New Sidekiq versions require at lease redis 7.3 to run. We have it
  hardcoded in this playbook at 6.x. I want to make it so we can change
  an env var and upgrade our Redis version

What were the changes made to support this:
- Add a new variable to the redis-variables.tf
- Set the default to 7.x
- use the variable in redis.tf